### PR TITLE
fix: header files not being found on linux

### DIFF
--- a/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_condition.c
+++ b/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_condition.c
@@ -26,7 +26,7 @@
 #include <errno.h>
 
 #if defined( _MSC_VER ) && defined( WINAPI ) && ( WINVER >= 0x0602 )
-#include <Synchapi.h>
+#include <synchapi.h>
 #endif
 
 #if defined( HAVE_PTHREAD_H ) && !defined( WINAPI )

--- a/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_condition.h
+++ b/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_condition.h
@@ -26,7 +26,7 @@
 #include <types.h>
 
 #if defined( _MSC_VER ) && defined( WINAPI ) && ( WINVER >= 0x0602 )
-#include <Synchapi.h>
+#include <synchapi.h>
 #endif
 
 #if defined( HAVE_PTHREAD_H ) && !defined( WINAPI )

--- a/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_mutex.c
+++ b/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_mutex.c
@@ -26,7 +26,7 @@
 #include <errno.h>
 
 #if defined( _MSC_VER ) && defined( WINAPI ) && ( WINVER >= 0x0602 )
-#include <Synchapi.h>
+#include <synchapi.h>
 #endif
 
 #if defined( HAVE_PTHREAD_H ) && !defined( WINAPI )

--- a/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_read_write_lock.c
+++ b/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_read_write_lock.c
@@ -26,7 +26,7 @@
 #include <errno.h>
 
 #if defined( _MSC_VER ) && defined( WINAPI ) && ( WINVER >= 0x0602 )
-#include <Synchapi.h>
+#include <synchapi.h>
 #endif
 
 #if defined( HAVE_PTHREAD_H ) && !defined( WINAPI )

--- a/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_read_write_lock.h
+++ b/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_read_write_lock.h
@@ -26,7 +26,7 @@
 #include <types.h>
 
 #if defined( _MSC_VER ) && defined( WINAPI ) && ( WINVER >= 0x0602 )
-#include <Synchapi.h>
+#include <synchapi.h>
 #endif
 
 #if defined( HAVE_PTHREAD_H ) && !defined( WINAPI )

--- a/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_repeating_thread.c
+++ b/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_repeating_thread.c
@@ -26,8 +26,8 @@
 #include <errno.h>
 
 #if defined( _MSC_VER ) && defined( WINAPI ) && ( WINVER >= 0x0602 )
-#include <Processthreadsapi.h>
-#include <Synchapi.h>
+#include <processthreadsapi.h>
+#include <synchapi.h>
 #endif
 
 #if defined( HAVE_PTHREAD_H ) && !defined( WINAPI )

--- a/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_thread.c
+++ b/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_thread.c
@@ -26,8 +26,8 @@
 #include <errno.h>
 
 #if defined( _MSC_VER ) && defined( WINAPI ) && ( WINVER >= 0x0602 )
-#include <Processthreadsapi.h>
-#include <Synchapi.h>
+#include <processthreadsapi.h>
+#include <synchapi.h>
 #endif
 
 #if defined( HAVE_PTHREAD_H ) && !defined( WINAPI )

--- a/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_thread_pool.c
+++ b/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_thread_pool.c
@@ -26,7 +26,7 @@
 #include <errno.h>
 
 #if defined( _MSC_VER ) && defined( WINAPI ) && ( WINVER >= 0x0602 )
-#include <Threadpoolapiset.h>
+#include <threadpoolapiset.h>
 #endif
 
 #include "libcthreads_condition.h"

--- a/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_thread_pool.h
+++ b/libesedb-sys/libesedb-20230824/libcthreads/libcthreads_thread_pool.h
@@ -26,7 +26,7 @@
 #include <types.h>
 
 #if defined( _MSC_VER ) && defined( WINAPI ) && ( WINVER >= 0x0602 )
-#include <Threadpoolapiset.h>
+#include <threadpoolapiset.h>
 #endif
 
 #include "libcthreads_extern.h"


### PR DESCRIPTION
Lowercase the names of imported header files to fix a problem with header files not being found on linux.

when cross compile via cargo-xwin，it cannot found header file beacause of Uppercase name

This commit will not affect compilation on windows because windows is case insensitive when looking for header files.