### PR TITLE
MultiValue returned wrong data: fix unsufficient memory allocation in multi_value.rs

### DIFF
--- a/src/multi_value.rs
+++ b/src/multi_value.rs
@@ -163,7 +163,7 @@ impl MultiValue<'_> {
                     entry,
                     &mut size
                 )?;
-                let mut buf = Vec::with_capacity(size);
+                let mut buf = vec![0; size as _];
                 ese_result!(
                     libesedb_multi_value_get_value_binary_data,
                     self.ptr,
@@ -181,7 +181,7 @@ impl MultiValue<'_> {
                     entry,
                     &mut size
                 )?;
-                let mut buf = Vec::with_capacity(size);
+                let mut buf = vec![0; size as _];
                 ese_result!(
                     libesedb_multi_value_get_value_utf8_string,
                     self.ptr,
@@ -202,7 +202,7 @@ impl MultiValue<'_> {
                     entry,
                     &mut size
                 )?;
-                let mut buf = Vec::with_capacity(size);
+                let mut buf = vec![0; size as _];
                 ese_result!(
                     libesedb_multi_value_get_value_binary_data,
                     self.ptr,
@@ -220,7 +220,7 @@ impl MultiValue<'_> {
                     entry,
                     &mut size
                 )?;
-                let mut buf = Vec::with_capacity(size);
+                let mut buf = vec![0; size as _];
                 ese_result!(
                     libesedb_multi_value_get_value_utf8_string,
                     self.ptr,
@@ -241,7 +241,7 @@ impl MultiValue<'_> {
                     entry,
                     &mut size
                 )?;
-                let mut buf = Vec::with_capacity(size);
+                let mut buf = vec![0; size as _];
                 ese_result!(
                     libesedb_multi_value_get_value_data,
                     self.ptr,
@@ -279,7 +279,7 @@ impl MultiValue<'_> {
                     entry,
                     &mut size
                 )?;
-                let mut buf = Vec::with_capacity(size);
+                let mut buf = vec![0; size as _];
                 ese_result!(
                     libesedb_multi_value_get_value_data,
                     self.ptr,


### PR DESCRIPTION
In `multi_value.rs`, buffers are "allocated" using `Vec::capacity`, which does not change the `len()` of the buffer. The result is that after calling `libesedb_multi_value_get_value_XXX`, `buf.len()` is still `0`, so that MultiValue always seems to contain empty TEXTs oder BINARYs.

Clearly, this is wrong and could be checked by inserting

```rust
assert_eq!(size, buf.len());
```

after the resp. calls to `libesedb_multi_value_get_value_XXX`, which fails with all my testdata, because `buf.len()` is always `0`.

The fix is to use the same allocation as you already did in `value.rs`. I suggested a fix in this pull request.